### PR TITLE
feat: add toggle button to mark task as done #3

### DIFF
--- a/todolist.js
+++ b/todolist.js
@@ -8,6 +8,15 @@ addEventListener("load", (event) => {
     // Put taskText into the list item
     listItem.innerText = text
 
+    // Create button to mark task as done
+    const doneBtn = document.createElement('button')
+    doneBtn.className = 'task-done-toggle'
+    doneBtn.innerText = '✔'
+    doneBtn.addEventListener('click', onTaskDoneToggleClick)
+
+    // add button to list item content
+    listItem.append(doneBtn)
+
     return listItem
   }
 
@@ -27,6 +36,22 @@ addEventListener("load", (event) => {
   
     // Reset input
     taskTitleInput.value = ''
+  }
+
+  function onTaskDoneToggleClick(event) {
+    // Retrieve button and its related task
+    const doneBtn = event.target
+    const task = doneBtn.parentElement
+
+    // Toggle 'done' status of the task
+    const isTaskAlreadyDone = task.classList.contains('done')
+    if (isTaskAlreadyDone) {
+      task.classList.remove('done')
+      doneBtn.innerText = '✔' 
+    } else {
+      task.classList.add('done')
+      doneBtn.innerText = '↶'
+    }
   }
 
   // Handle form submission


### PR DESCRIPTION
When a task is created, a button has been added to toggle the task `done` status.

When the task is not done yet:
 - button has ✔ as text for now
 - task has no specific class

When the task is done:
- button has ↶ as text for now
- task has `done` class

Linked issue : https://github.com/tifainehiaume-glitch/to-do-list/issues/3